### PR TITLE
Fix issue where stacktraces were been captured even when explicitly setup to be excluded

### DIFF
--- a/src/main/java/dev/morling/jfrunit/EnableEvent.java
+++ b/src/main/java/dev/morling/jfrunit/EnableEvent.java
@@ -18,6 +18,7 @@ package dev.morling.jfrunit;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+
 /**
  * Enables a specific JFR event type, e.g. "jdk.GarbageCollection" for a recording.
  *
@@ -32,18 +33,16 @@ public @interface EnableEvent {
      */
     String value() default "";
 
-//    String name() default "";
-
-    StacktracePolicy stackTrace() default StacktracePolicy.DEFAULT;
+    StacktracePolicy stackTrace() default StacktracePolicy.INCLUDED;
 
     int threshold() default -1;
 
-    public enum StacktracePolicy {
-        DEFAULT, INCLUDED, EXCLUDED;
+    enum StacktracePolicy {
+        INCLUDED, EXCLUDED
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface List {
+    @interface List {
         EnableEvent[] value();
     }
 }

--- a/src/main/java/dev/morling/jfrunit/JfrEvents.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEvents.java
@@ -136,8 +136,7 @@ public class JfrEvents {
     private void awaitStreamStart(CountDownLatch streamStarted) throws InterruptedException {
         while(streamStarted.getCount() != 0) {
             SyncEvent event = new SyncEvent();
-            long seq = sequence.incrementAndGet();
-            event.sequence = seq;
+            event.sequence = sequence.incrementAndGet();
             event.cause = "awaiting stream start";
             event.begin();
             event.commit();
@@ -158,7 +157,7 @@ public class JfrEvents {
                 if (enabledEvent.stackTrace == StacktracePolicy.INCLUDED) {
                     settings.withStackTrace();
                 }
-                else if (enabledEvent.stackTrace == StacktracePolicy.INCLUDED) {
+                else if (enabledEvent.stackTrace == StacktracePolicy.EXCLUDED) {
                     settings.withoutStackTrace();
                 }
 
@@ -187,7 +186,7 @@ public class JfrEvents {
                 if (enabledEvent.stackTrace == StacktracePolicy.INCLUDED) {
                     settings.withStackTrace();
                 }
-                else if (enabledEvent.stackTrace == StacktracePolicy.INCLUDED) {
+                else if (enabledEvent.stackTrace == StacktracePolicy.EXCLUDED) {
                     settings.withoutStackTrace();
                 }
 

--- a/src/main/java/dev/morling/jfrunit/JfrEventsAssert.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEventsAssert.java
@@ -31,16 +31,20 @@ public class JfrEventsAssert extends AbstractAssert<JfrEventsAssert, JfrEvents> 
         isNotNull();
 
         boolean found = actual.getEvents()
-            .filter(re -> ExpectedEvent.matches(expectedEvent, re))
-            .findAny()
-            .isPresent();
+            .anyMatch(re -> ExpectedEvent.matches(expectedEvent, re));
 
         if (!found) {
-            if (expectedEvent.getProps().isEmpty()) {
+            if (expectedEvent.getWithProps().isEmpty() && expectedEvent.getHasProps().isEmpty() && expectedEvent.getHasNotProps().isEmpty()) {
                 failWithMessage("No JFR event of type <%s>", expectedEvent.getName());
             }
+            else if(!expectedEvent.getHasProps().isEmpty()) {
+                failWithMessage("No JFR event of type <%s> with attributes <%s>", expectedEvent.getName(), expectedEvent.getHasProps());
+            }
+            else if(!expectedEvent.getHasNotProps().isEmpty()) {
+                failWithMessage("No JFR event of type <%s> without attributes <%s>", expectedEvent.getName(), expectedEvent.getHasNotProps());
+            }
             else {
-                failWithMessage("No JFR event of type <%s> with attributes <%s>", expectedEvent.getName(), expectedEvent.getProps());
+                failWithMessage("No JFR event of type <%s> with attributes <%s>", expectedEvent.getName(), expectedEvent.getWithProps());
             }
         }
 

--- a/src/test/java/dev/morling/jfrunit/JfrUnitTest.java
+++ b/src/test/java/dev/morling/jfrunit/JfrUnitTest.java
@@ -15,13 +15,13 @@
  */
 package dev.morling.jfrunit;
 
-import static dev.morling.jfrunit.ExpectedEvent.event;
-import static dev.morling.jfrunit.JfrEventsAssert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import org.junit.jupiter.api.Test;
+import static dev.morling.jfrunit.ExpectedEvent.event;
+import static dev.morling.jfrunit.JfrEventsAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @JfrEventTest
 public class JfrUnitTest {
@@ -69,5 +69,35 @@ public class JfrUnitTest {
                 .sum();
 
         assertThat(allocated).isGreaterThan(0);
+    }
+
+    @Test
+    @EnableEvent("jdk.ThreadSleep")
+    public void shouldHaveStackTraceCapturedWithNoStackTracePolicyDefined() throws Exception {
+        Thread.sleep(1000);
+
+        jfrEvents.awaitEvents();
+
+        assertThat(jfrEvents).contains(event("jdk.ThreadSleep").has("stackTrace"));
+    }
+
+    @Test
+    @EnableEvent(value = "jdk.ThreadSleep", stackTrace = EnableEvent.StacktracePolicy.INCLUDED)
+    public void shouldHaveStackTraceCapturedWithStackTracePolicyIncluded() throws Exception {
+        Thread.sleep(1000);
+
+        jfrEvents.awaitEvents();
+
+        assertThat(jfrEvents).contains(event("jdk.ThreadSleep").has("stackTrace"));
+    }
+
+    @Test
+    @EnableEvent(value = "jdk.ThreadSleep", stackTrace = EnableEvent.StacktracePolicy.EXCLUDED)
+    public void shouldNotHaveStackTraceCapturedWithStackTracePolicyExcluded() throws Exception {
+        Thread.sleep(1000);
+
+        jfrEvents.awaitEvents();
+
+        assertThat(jfrEvents).contains(event("jdk.ThreadSleep").hasNot("stackTrace"));
     }
 }


### PR DESCRIPTION
Fix issue where stacktraces were been captured even when explicitly setup to be excluded.
Added test cases will fail for the scenario where stackTrace field is not expected but is found.

Signed-off-by: Tushar Badgu <tushar.badgu@gmail.com>